### PR TITLE
Cbateman/improve create profile

### DIFF
--- a/plugins/src/com/oracle/oci/eclipse/ui/explorer/database/ConfigureADBConnectionProfile.java
+++ b/plugins/src/com/oracle/oci/eclipse/ui/explorer/database/ConfigureADBConnectionProfile.java
@@ -10,7 +10,6 @@ import java.util.Properties;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.core.runtime.SubProgressMonitor;
 import org.eclipse.datatools.connectivity.ConnectionProfileException;
 import org.eclipse.datatools.connectivity.IConnectionProfile;
 import org.eclipse.datatools.connectivity.ProfileManager;
@@ -95,7 +94,7 @@ public class ConfigureADBConnectionProfile {
 
 	public static void createConnectionProfile(
 			IProgressMonitor monitor, AutonomousDatabaseSummary adbInstance, String user,
-			String password, String walletLocation, String aliasName) throws ConnectionProfileException {
+			String password, String walletLocation, String aliasName, boolean autoConnect) throws ConnectionProfileException {
 		
 		final String regionName = AuthProvider.getInstance().getRegion().toString();
 		final String profileName = user.toUpperCase()+"."+aliasName+"."+regionName;
@@ -103,15 +102,36 @@ public class ConfigureADBConnectionProfile {
 		final String url = "jdbc:oracle:thin:@"+aliasName+"?TNS_ADMIN="+walletLocation;
 		
 		monitor.beginTask("Configuring database connection", 5);
-    	IProgressMonitor subMonitor = new SubProgressMonitor(monitor, 4);
-    	subMonitor.beginTask("Creating connection profile", 1);
+		monitor.subTask("Creating connection profile");
 		
 		DriverInstance driverInstance = getDriverInstance();
 		IConnectionProfile profile = getConnectionProfile(driverInstance, profileName, user, password, url);
 		ErrorHandler.logInfo("Connection profile created successfully for database : " + adbInstance.getDbName());
-		subMonitor.worked(1);
+		monitor.worked(1);
 		monitor.subTask("Connecting...");
-		ConfigureADBConnectionProfile.connectAndRevealConnectionProfile(profile);
+		if (monitor.isCanceled())
+		{
+		    return;
+		}
+		
+		if (autoConnect)
+		{
+	        org.eclipse.core.runtime.jobs.Job job = new org.eclipse.core.runtime.jobs.Job("Make remote JDBC connection") {
+	            @Override
+	            protected IStatus run(IProgressMonitor monitor) {
+	                return connectAndRevealConnectionProfile(profile);
+	            }
+
+                @Override
+                protected void canceling() {
+                    
+                    getThread().interrupt();
+                }
+	            
+	            
+	        };
+	        job.schedule();
+		}
 		monitor.worked(1);
 	}
 	
@@ -176,21 +196,8 @@ public class ConfigureADBConnectionProfile {
      * @param connectionProfile
      *            The connection profile to connect and reveal
      */
-    public static void connectAndRevealConnectionProfile(final IConnectionProfile connectionProfile) {
-        IStatus connectStatus = connectionProfile.connect();
-        if (connectStatus.isOK() == false) {
-        	try {
-				ProfileManager.getInstance().deleteProfile(connectionProfile);
-			} catch (Exception e) {
-				ErrorHandler.logInfo("Could not delete connection profile: " + e.getMessage());
-			}
-			Status status = new Status(IStatus.ERROR, Activator.PLUGIN_ID,
-					"Unable to connect to the Autonomous database.  Make sure your password is correct"
-					+ "\n and you can access your database through your network and any firewalls you may be connecting through.");
-            StatusManager.getManager().handle(status, StatusManager.BLOCK | StatusManager.LOG);
-            return;
-        }
-
+    public static IStatus connectAndRevealConnectionProfile(final IConnectionProfile connectionProfile) {
+        // TODO: does it really make sense to delete the profile if there's an error?
         Display.getDefault().syncExec(new Runnable() {
             @Override
             public void run() {
@@ -212,6 +219,20 @@ public class ConfigureADBConnectionProfile {
                 }
             }
         });
+        IStatus connectStatus = connectionProfile.connect();
+        if (connectStatus != null && !connectStatus.isOK()) {
+            try {
+                ProfileManager.getInstance().deleteProfile(connectionProfile);
+            } catch (Exception e) {
+                ErrorHandler.logInfo("Could not delete connection profile: " + e.getMessage());
+            }
+            Status status = new Status(IStatus.ERROR, Activator.PLUGIN_ID,
+                    "Unable to connect to the Autonomous database.  Make sure your password is correct"
+                    + "\n and you can access your database through your network and any firewalls you may be connecting through.");
+            StatusManager.getManager().handle(status, StatusManager.BLOCK | StatusManager.LOG);
+            return connectStatus;
+        }
+        return connectStatus == null ? new Status(IStatus.ERROR, ConfigureADBConnectionProfile.class, "Error connecting the profile") : connectStatus;
     }
     
 }

--- a/plugins/src/com/oracle/oci/eclipse/ui/explorer/database/CreateADBConnectionWizard.java
+++ b/plugins/src/com/oracle/oci/eclipse/ui/explorer/database/CreateADBConnectionWizard.java
@@ -47,15 +47,17 @@ public class CreateADBConnectionWizard  extends Wizard implements INewWizard {
     	final String password = page.getPassword();
     	final String walletLocation = page.getWalletDirectory();
     	final String aliasName = page.getSelectedAlias();
+    	final boolean autoConnect = page.isAutoConnectProfile();  // no need to validate
     	
-    	if(!validateInput(user, password, walletLocation, aliasName))
+    	if(!validateInput(user, password, walletLocation, aliasName)) {
     		return false;
+    	}
     	
     	IRunnableWithProgress op = new IRunnableWithProgress() {
             @Override
 			public void run(IProgressMonitor monitor) throws InvocationTargetException {
 				try {
-					ConfigureADBConnectionProfile.createConnectionProfile(monitor, adbInstance, user, password,walletLocation, aliasName);
+					ConfigureADBConnectionProfile.createConnectionProfile(monitor, adbInstance, user, password,walletLocation, aliasName, autoConnect);
 				} catch (Exception e) {
 					ErrorHandler.logErrorStack("Error occured while creating connection to database: " + adbInstance.getDbName(), e);
 					throw new InvocationTargetException(e);
@@ -66,7 +68,7 @@ public class CreateADBConnectionWizard  extends Wizard implements INewWizard {
         };
         
         try {
-            getContainer().run(true, false, op);
+            getContainer().run(true, true, op);
         } catch (InterruptedException e) {
             return false;
         } catch (InvocationTargetException e) {

--- a/plugins/src/com/oracle/oci/eclipse/ui/explorer/database/CreateADBConnectionWizardPage.java
+++ b/plugins/src/com/oracle/oci/eclipse/ui/explorer/database/CreateADBConnectionWizardPage.java
@@ -255,7 +255,7 @@ public class CreateADBConnectionWizardPage extends WizardPage {
 
 	private IStatus validateWalletDirectory(String walletDirStr)
 	{
-	    if (walletDirStr == null || walletDirStr.isBlank())
+	    if (walletDirStr == null || walletDirStr.trim().isEmpty())
 	    {
 	        return new Status(IStatus.ERROR, getClass(), "Wallet Directory cannot be empty");
 	    }

--- a/plugins/src/com/oracle/oci/eclipse/ui/explorer/database/CreateADBConnectionWizardPage.java
+++ b/plugins/src/com/oracle/oci/eclipse/ui/explorer/database/CreateADBConnectionWizardPage.java
@@ -6,12 +6,14 @@ package com.oracle.oci.eclipse.ui.explorer.database;
 
 import java.io.File;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyEvent;
@@ -39,6 +41,7 @@ public class CreateADBConnectionWizardPage extends WizardPage {
 	private Text passwordText;
 	private Text walletDirText;
 	private AutonomousDatabaseSummary adbInstance;
+    private Button autoConnectCheckBox;
 
 	public CreateADBConnectionWizardPage(AutonomousDatabaseSummary adbInstance) {
 		super("wizardPage");
@@ -87,7 +90,8 @@ public class CreateADBConnectionWizardPage extends WizardPage {
 
         walletDirText = new Text(innerContainer, SWT.BORDER | SWT.SINGLE);
         walletDirText.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-        walletDirText.setEditable(false);
+        //walletDirText.setEditable(true);
+        
         
         walletDirText.addModifyListener(new ModifyListener() {
             @Override
@@ -102,11 +106,14 @@ public class CreateADBConnectionWizardPage extends WizardPage {
             @Override
             public void widgetSelected(SelectionEvent e) {
             	final String walletDirPath = handleBrowse(innerContainer.getShell(), walletDirText.getText());
-            	if(walletDirPath != null)
+            	if(walletDirPath != null) {
+            	    IStatus status = validateWalletDirectory(walletDirPath);
+            	    updateStatus(status);
             		walletDirText.setText(walletDirPath);
+            	}
             }
         });
-		
+
         Composite innerBottomContainer = new Composite(topLevelContainer, SWT.NONE);
         GridLayout innerBottomLayout = new GridLayout();
         innerBottomLayout.numColumns = 2;
@@ -128,6 +135,13 @@ public class CreateADBConnectionWizardPage extends WizardPage {
 			aliasList.select(0);
 		}
 		
+		this.autoConnectCheckBox = new Button(innerBottomContainer, SWT.CHECK);
+		autoConnectCheckBox.setSelection(true); // auto-connect by default
+		GridData gdCheckBox = GridDataFactory.copyData(gd3);
+		gdCheckBox.horizontalSpan = 2;
+        this.autoConnectCheckBox.setLayoutData(gdCheckBox);
+		this.autoConnectCheckBox.setText("Automatically connect after profile is created");
+        
 		final String configFilePath = PreferencesWrapper.getConfigFileName();
         if(configFilePath != null) {
         	final String configFileDirPath = configFilePath.substring(0, configFilePath.lastIndexOf(File.separator));
@@ -147,11 +161,12 @@ public class CreateADBConnectionWizardPage extends WizardPage {
     	if(walletLocation == null || walletLocation.trim().equals(""))
     		return tnsEntries;
 		try {
-			String tnsnamesOraFileLoc = walletLocation+File.separator+"tnsnames.ora";
-			if (!(new File(tnsnamesOraFileLoc).exists()))
+			File tnsnamesOraFile = getTnsOraFile(walletLocation);
+            
+			if (!tnsnamesOraFile.exists()) {
 				return tnsEntries;
-			
-			List<String> allLines = Files.readAllLines(Paths.get(tnsnamesOraFileLoc));
+			}
+			List<String> allLines = Files.readAllLines(tnsnamesOraFile.toPath());
 			for (String line : allLines) {
 				if(line != null && line.trim().startsWith(dbName.toLowerCase()+"_")) {
 					int index = line.indexOf("=");
@@ -166,6 +181,15 @@ public class CreateADBConnectionWizardPage extends WizardPage {
 		}
 		return tnsEntries;
     }
+
+    private File getTnsOraFile(String walletLocation) {
+        String tnsnamesOraFileLoc = getTnsOraFileLoc(walletLocation);
+        return new File(tnsnamesOraFileLoc);
+    }
+
+    private String getTnsOraFileLoc(String walletLocation) {
+        return walletLocation + File.separator + "tnsnames.ora";
+    }
 	
 	private String handleBrowse(Shell shell, String currentWalletDir) {
     	DirectoryDialog dialog = new DirectoryDialog(shell, SWT.OPEN);
@@ -175,17 +199,34 @@ public class CreateADBConnectionWizardPage extends WizardPage {
     }
 	
 	private void walletDirectoryChanged() {
-		aliasList.clearSelection();
-		aliasList.removeAll();
-		Set<String> aliasSet = getTnsEntries(getWalletDirectory());
-		if (aliasSet.size() > 0) {
-			Iterator<String> it = aliasSet.iterator();
-			while (it.hasNext()) {
-				aliasList.add(it.next());
-			}
-			aliasList.select(0);
-		}
+	    String walletDirectory = getWalletDirectory();
+        IStatus status = validateWalletDirectory(walletDirectory);
+        
+        if (status.isOK())
+        {
+            updateStatus((String)null);
+            aliasList.setEnabled(true);
+    		aliasList.clearSelection();
+    		aliasList.removeAll();
+    		Set<String> aliasSet = getTnsEntries(walletDirectory);
+    		if (aliasSet.size() > 0) {
+    			Iterator<String> it = aliasSet.iterator();
+    			while (it.hasNext()) {
+    				aliasList.add(it.next());
+    			}
+    			aliasList.select(0);
+    		}
+        }
+        else
+        {
+            updateStatus(status.getMessage());
+            aliasList.setEnabled(false);
+        }
 	}
+
+    private void updateStatus(IStatus status) {
+        updateStatus(status.getMessage());
+    }
 
 	private void updateStatus(String message) {
 		setErrorMessage(message);
@@ -207,5 +248,27 @@ public class CreateADBConnectionWizardPage extends WizardPage {
 	public String getWalletDirectory() {
 		return walletDirText.getText();
 	}
+	
+	public boolean isAutoConnectProfile() {
+	    return autoConnectCheckBox.getSelection();
+	}
 
+	private IStatus validateWalletDirectory(String walletDirStr)
+	{
+	    if (walletDirStr == null || walletDirStr.isBlank())
+	    {
+	        return new Status(IStatus.ERROR, getClass(), "Wallet Directory cannot be empty");
+	    }
+	    File walletDir = new File(walletDirStr);
+	    if (!walletDir.isDirectory())
+	    {
+	        return new Status(IStatus.ERROR, getClass(), String.format("%s must be an accessible directory", walletDirStr));
+	    }
+	    File tnsOraFile = getTnsOraFile(walletDirStr);
+	    if (!tnsOraFile.exists()) {
+	        return new Status(IStatus.ERROR, getClass(), 
+	                String.format("Can't find tnsnames.ora in wallet directory %s", walletDirStr));
+	    }
+	    return Status.OK_STATUS;
+	}
 }


### PR DESCRIPTION
Having used the tooling to do a number of DB create/connect scenarios, one issue I ran into is that when a connection profile is created, the blocking calls to the remote server are done on the UI thread.  This means, for example, if you happen to do this behind an unproxied firewall, your entire Eclipse session can be blocked until the relevant timeouts occur: really annoying.  I also added a checkbox so a user can defer trying to connect their profile.